### PR TITLE
fix: handle Firefox location correctly on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 var spawn = require('child_process').spawn;
-
+var os = require('os');
 
 var PREFS =
     'user_pref("browser.shell.checkDefaultBrowser", false);\n' +
@@ -70,8 +70,8 @@ FirefoxNightlyBrowser.prototype = {
 
 FirefoxNightlyBrowser.$inject = ['id', 'baseBrowserDecorator', 'logger'];
 
-function windowsFirefoxPath(firefoxExe) {
-	var programFiles = require('os').arch()==='x64' ? process.env['ProgramFiles(x86)'] : process.env.ProgramFiles;
+var windowsFirefoxPath = function(firefoxExe) {
+	var programFiles = os.arch()==='x64' ? process.env['ProgramFiles(x86)'] : process.env.ProgramFiles;
 	return programFiles + firefoxExe;
 }
 


### PR DESCRIPTION
Handle the differences between 32 and 64 bit Windows when building the
path to the Firefox bin
