### PR TITLE
fix: handle Firefox location on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,24 @@ var PREFS =
     'user_pref("browser.bookmarks.restore_default_bookmarks", false);\n';
 
 
+// Return location of firefox.exe file for a given Firefox directory
+// (available: "Mozilla Firefox", "Aurora", "Nightly").
+function getFirefoxExe(firefoxDirName) {
+  var windowsFirefoxDirectory, i, prefix;
+  var suffix = '\\'+ firefoxDirName + '\\firefox.exe';
+  var prefixes = [process.env.PROGRAMFILES, process.env['PROGRAMFILES(X86)']];
+
+  for (i = 0; i < prefixes.length; i++) {
+    prefix = prefixes[i];
+    if (fs.existsSync(prefix + suffix)) {
+      windowsFirefoxDirectory = prefix + suffix;
+      break;
+    }
+  }
+
+  return windowsFirefoxDirectory;
+}
+
 // https://developer.mozilla.org/en-US/docs/Command_Line_Options
 var FirefoxBrowser = function(id, baseBrowserDecorator, logger) {
   baseBrowserDecorator(this);
@@ -29,7 +47,7 @@ FirefoxBrowser.prototype = {
   DEFAULT_CMD: {
     linux: 'firefox',
     darwin: '/Applications/Firefox.app/Contents/MacOS/firefox-bin',
-    win32: process.env.ProgramFiles + '\\Mozilla Firefox\\firefox.exe'
+    win32: getFirefoxExe('Mozilla Firefox')
   },
   ENV_CMD: 'FIREFOX_BIN'
 };
@@ -46,7 +64,7 @@ FirefoxAuroraBrowser.prototype = {
   DEFAULT_CMD: {
     linux: 'firefox',
     darwin: '/Applications/FirefoxAurora.app/Contents/MacOS/firefox-bin',
-    win32: process.env.ProgramFiles + '\\Aurora\\firefox.exe'
+    win32: getFirefoxExe('Aurora')
   },
   ENV_CMD: 'FIREFOX_AURORA_BIN'
 };
@@ -64,7 +82,7 @@ FirefoxNightlyBrowser.prototype = {
   DEFAULT_CMD: {
     linux: 'firefox',
     darwin: '/Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin',
-    win32: process.env.ProgramFiles + '\\Nightly\\firefox.exe'
+    win32: getFirefoxExe('Nightly')
   },
   ENV_CMD: 'FIREFOX_NIGHTLY_BIN'
 };


### PR DESCRIPTION
Currently the task assumes Firefox is located under process.env.PROGRAMFILES
directory. This is not true, as Firefox, being 32-bit on Windows, is located
in process.env["PROGRAMFILES(X86)"]. This commit adds a fallback to the second path,
being forward-compatible in case 64-bit Firefox gets released for Windows.

Analogous PR for Chrome: https://github.com/karma-runner/karma-chrome-launcher/pull/6
