### PR TITLE
Change Firefox win32 path to 'Program Files (x86)'

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ FirefoxBrowser.prototype = {
   DEFAULT_CMD: {
     linux: 'firefox',
     darwin: '/Applications/Firefox.app/Contents/MacOS/firefox-bin',
-    win32: process.env.ProgramFiles + '\\Mozilla Firefox\\firefox.exe'
+    win32: process.env['ProgramFiles(x86)'] + '\\Mozilla Firefox\\firefox.exe'
   },
   ENV_CMD: 'FIREFOX_BIN'
 };
@@ -46,7 +46,7 @@ FirefoxAuroraBrowser.prototype = {
   DEFAULT_CMD: {
     linux: 'firefox',
     darwin: '/Applications/FirefoxAurora.app/Contents/MacOS/firefox-bin',
-    win32: process.env.ProgramFiles + '\\Aurora\\firefox.exe'
+    win32: process.env['ProgramFiles(x86)'] + '\\Aurora\\firefox.exe'
   },
   ENV_CMD: 'FIREFOX_AURORA_BIN'
 };
@@ -64,7 +64,7 @@ FirefoxNightlyBrowser.prototype = {
   DEFAULT_CMD: {
     linux: 'firefox',
     darwin: '/Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin',
-    win32: process.env.ProgramFiles + '\\Nightly\\firefox.exe'
+    win32: process.env['ProgramFiles(x86)'] + '\\Nightly\\firefox.exe'
   },
   ENV_CMD: 'FIREFOX_NIGHTLY_BIN'
 };


### PR DESCRIPTION
Best I can tell, there is no officially-supported 64-bit version of FF at the moment:

https://support.mozilla.org/en-US/questions/782154
https://developer.mozilla.org/en-US/docs/Supported_build_configurations

Unofficial? 64-bit version indicates there isn't an official one?
http://www.firefox64bit.com/

On my machine, both Aurora and FF are installed in 'Program Files (x86)', which makes sense for a 32-bit program (http://www.samlogic.net/articles/32-64-bit-windows-folder-x86-syswow64.htm) so I think this may be a better default.
