### PR TITLE
feat: Added ability to set custom preferences in firefox

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ var getFirefoxExe = function(firefoxDirName) {
     return null;
   }
 
+
   var prefix;
   var prefixes = [process.env.PROGRAMFILES, process.env['PROGRAMFILES(X86)']];
   var suffix = '\\'+ firefoxDirName + '\\firefox.exe';
@@ -31,16 +32,26 @@ var getFirefoxExe = function(firefoxDirName) {
 }
 
 // https://developer.mozilla.org/en-US/docs/Command_Line_Options
-var FirefoxBrowser = function(id, baseBrowserDecorator, logger) {
+var FirefoxBrowser = function(id, baseBrowserDecorator, args, logger) {
   baseBrowserDecorator(this);
 
   var log = logger.create('launcher');
+  this._getPrefs = function(prefs) {
+    if (typeof prefs !== 'object') {
+      return PREFS;
+    }
+    var result = PREFS;
+    for (var key in prefs) {
+      result += 'user_pref("' + key + '", ' + JSON.stringify(prefs[key]) + ');\n';
+    }
+    return result;
+  }
 
   this._start = function(url) {
     var self = this;
     var command = this._getCommand();
 
-    fs.writeFileSync(self._tempDir + '/prefs.js', PREFS);
+    fs.writeFileSync(self._tempDir + '/prefs.js', this._getPrefs(args.prefs));
     self._execCommand(command, [url, '-profile', self._tempDir, '-no-remote']);
   };
 };
@@ -57,7 +68,7 @@ FirefoxBrowser.prototype = {
   ENV_CMD: 'FIREFOX_BIN'
 };
 
-FirefoxBrowser.$inject = ['id', 'baseBrowserDecorator', 'logger'];
+FirefoxBrowser.$inject = ['id', 'baseBrowserDecorator', 'args', 'logger'];
 
 
 var FirefoxAuroraBrowser = function(id, baseBrowserDecorator, logger) {
@@ -74,7 +85,7 @@ FirefoxAuroraBrowser.prototype = {
   ENV_CMD: 'FIREFOX_AURORA_BIN'
 };
 
-FirefoxAuroraBrowser.$inject = ['id', 'baseBrowserDecorator', 'logger'];
+FirefoxAuroraBrowser.$inject = ['id', 'baseBrowserDecorator', 'args', 'logger'];
 
 
 var FirefoxNightlyBrowser = function(id, baseBrowserDecorator, logger) {
@@ -92,7 +103,7 @@ FirefoxNightlyBrowser.prototype = {
   ENV_CMD: 'FIREFOX_NIGHTLY_BIN'
 };
 
-FirefoxNightlyBrowser.$inject = ['id', 'baseBrowserDecorator', 'logger'];
+FirefoxNightlyBrowser.$inject = ['id', 'baseBrowserDecorator', 'args', 'logger'];
 
 
 // PUBLISH DI MODULE


### PR DESCRIPTION
Added the ability for firefox to take in custom preferences.

I am working on https://github.com/axemclion/karma-telemetry and I needed to pass in `dom.send_after_paint_to_content` for measuring first paint time and `dom.disable_open_during_load` to enable the tests to open in a new window. For now, I had to copy the code to create a new launcher, but it would be awesome if I could simply pass these preferences in to firefox. 

Tried to model this after the karma-chrome-launcher _getOptions function. 

Tested this on Windows with the following cases 
-  Default Firefox browsers works (no custom launcher)
- Custom launcher with no preferences works
- Custom launcher with {base: 'firefox', 'prefs': {} } works
- Custom launcher with {base: 'firefox', 'prefs': {'dom.send_after_paint_to_content' : true} } works
