### PR TITLE
FreeBSD support OOTB.

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ FirefoxBrowser.prototype = {
 
   DEFAULT_CMD: {
     linux: 'firefox',
+    freebsd: 'firefox',
     darwin: '/Applications/Firefox.app/Contents/MacOS/firefox-bin',
     win32: getFirefoxExe('Mozilla Firefox')
   },


### PR DESCRIPTION
One line change to support FreeBSD without requiring users on that platform to set the FIREFOX_BIN env variable.