### PR TITLE
add support of custom profile by using customLaunchers of karma config

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,9 +50,10 @@ var FirefoxBrowser = function(id, baseBrowserDecorator, args, logger) {
   this._start = function(url) {
     var self = this;
     var command = this._getCommand();
+    var profilePath = args.profile || self._tempDir;
 
     fs.writeFileSync(self._tempDir + '/prefs.js', this._getPrefs(args.prefs));
-    self._execCommand(command, [url, '-profile', self._tempDir, '-no-remote']);
+    self._execCommand(command, [url, '-profile', profilePath, '-no-remote']);
   };
 };
 


### PR DESCRIPTION
Cause of supporting client certificates we needed to start firefox with a custom profile folder.
Therefor I used the `customLauncher` attributes of Karma to set the path to the firefox launcher, but it ignored it. So I have done this change.

New with the following config the firefox starts with the given profile 
```
    customLaunchers: {
        FirefoxProfile: {
            base: 'Firefox',
            profile: '<path to profile>'
        }
    },

```