### PR TITLE
feat (runner): Add custom profile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,41 @@ You can pass list of browsers as a CLI argument too:
 karma start --browsers Firefox,Chrome
 ```
 
+To configure preferences for the Firefox instance that is loaded, you can specify a custom launcher in your Karma
+config with the preferences under the `prefs` key:
+
+```js
+browsers: ['FirefoxAutoAllowGUM'],
+
+customLaunchers: {
+    FirefoxAutoAllowGUM: {
+        base: 'Firefox',
+        prefs: {
+            'media.navigator.permission.disabled': true
+        }
+    }
+}
+```
+
+Alternatively, if you have more advanced use cases, you can specify the full path to a profile you wish the browser
+to use in the `profile` key:
+
+```js
+browsers: ['FirefoxCustomProfile'],
+
+customLaunchers: {
+    FirefoxCustomProfile: {
+        base: 'Firefox',
+        profile: '/users/liz/profiles/firefoxCustomProfile/'
+    }
+}
+```
+
+To learn more about setting up a custom firefox profile, see [this mozilla support article]
+(https://support.mozilla.org/en-US/kb/profile-manager-create-and-remove-firefox-profiles).
+
+**Note**: `prefs` and `profile` are mutually exclusive. If you specify a `profile`, the `prefs` will not be set.
+
 ----
 
 For more information on Karma see the [homepage].

--- a/index.js
+++ b/index.js
@@ -50,9 +50,13 @@ var FirefoxBrowser = function(id, baseBrowserDecorator, args, logger) {
   this._start = function(url) {
     var self = this;
     var command = this._getCommand();
+    var profilePath = args.profile || self._tempDir;
 
-    fs.writeFileSync(self._tempDir + '/prefs.js', this._getPrefs(args.prefs));
-    self._execCommand(command, [url, '-profile', self._tempDir, '-no-remote']);
+    if (!args.profile) {
+      fs.writeFileSync(profilePath + '/prefs.js', this._getPrefs(args.prefs));
+    }
+
+    self._execCommand(command, [url, '-profile', profilePath, '-no-remote']);
   };
 };
 


### PR DESCRIPTION
Allow a `profile` to be set in the arguments to the launcher,
so that more advanced users can setup their own profile manually.

Closes #33