### PR TITLE
feat: allow user to specify profile folder location

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ var FirefoxBrowser = function(id, baseBrowserDecorator, args, logger) {
     var extensionsDir;
 
     if (Array.isArray(args.extensions)) {
-      extensionsDir = path.resolve(self._tempDir, 'extensions');
+      extensionsDir = path.resolve(profilePath, 'extensions');
       fs.mkdirSync(extensionsDir);
       args.extensions.forEach(function (ext) {
         var extBuffer = fs.readFileSync(ext);
@@ -86,7 +86,7 @@ var FirefoxBrowser = function(id, baseBrowserDecorator, args, logger) {
       });
     }
 
-    fs.writeFileSync(self._tempDir + '/prefs.js', this._getPrefs(args.prefs));
+    fs.writeFileSync(profilePath + '/prefs.js', this._getPrefs(args.prefs));
     self._execCommand(
       command,
       [url, '-profile', profilePath, '-no-remote'].concat(flags)


### PR DESCRIPTION
Firefox has issue with VirtualBox shared folders https://bugzilla.mozilla.org/show_bug.cgi?id=801274 which is used with Docker setup. This change allow to specify profile path outside of shared folder ( e.g. /tmp/firefox ) and thus make firefox start properly.

Fixes #43