### PR TITLE
Add Profile Choice Functionality To The Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ Example:
 browsers: ['FirefoxWithMyExtension'],
 
 customLaunchers: {
-	FirefoxWithMyExtension: {
-		base: 'Firefox',
-		customProfile: 'Karma',
-		extensions: [
-			path.resolve(__dirname, '../my@extention.com.xpi'),
-		]
-	}
+  FirefoxWithMyExtension: {
+	base: 'Firefox',
+	customProfile: 'Karma',
+	extensions: [
+	  path.resolve(__dirname, '../my@extention.com.xpi'),
+	]
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,26 @@ customLaunchers: {
     }
 }
 ```
+### Starting a specific FF profile by its name
+
+When adding "customProfile" to the "customLauncher" Firefox will launch said profile. The profiles list is shown when you execute "firefox.exe -p". 
+Example:
+
+```js
+browsers: ['FirefoxWithMyExtension'],
+
+customLaunchers: {
+	FirefoxWithMyExtension: {
+		base: 'Firefox',
+		customProfile: 'Karma',
+		extensions: [
+			path.resolve(__dirname, '../my@extention.com.xpi'),
+		]
+	}
+}
+```
+
+This will upload the "karma" firefox i've setup beforehand using "firefox.exe -p", in it, my configs, such as imported certs.
 
 **Please note**: the extension name must exactly match the 'id' of the extension. You can discover the 'id' of your
 extension by extracting the .xpi (i.e. `unzip XXX.xpi`) and opening the install.RDF file with a text editor, then look

--- a/index.js
+++ b/index.js
@@ -94,6 +94,7 @@ var FirefoxBrowser = function(id, baseBrowserDecorator, args, logger) {
     }
 
     fs.writeFileSync(profilePath + '/prefs.js', this._getPrefs(args.prefs));
+    (customProfile !== '') ? flags = [] : null ;
     self._execCommand(
       command,
       [url, (customProfile !== '') ? '-p ' + customProfile : '-profile ' + profilePath , '-no-remote'].concat(flags)

--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ var FirefoxBrowser = function(id, baseBrowserDecorator, args, logger) {
     fs.writeFileSync(profilePath + '/prefs.js', this._getPrefs(args.prefs));
     self._execCommand(
       command,
-        [url, (customProfile !== '') ? '-p ' + customProfile : '-profile' + profilePath , '-no-remote'].concat(flags)
+      [url, (customProfile !== '') ? '-p ' + customProfile : '-profile ' + profilePath , '-no-remote'].concat(flags)
     );
   };
 };

--- a/index.js
+++ b/index.js
@@ -94,7 +94,6 @@ var FirefoxBrowser = function(id, baseBrowserDecorator, args, logger) {
     }
 
     fs.writeFileSync(profilePath + '/prefs.js', this._getPrefs(args.prefs));
-    (customProfile !== '') ? flags = [] : null ;
     self._execCommand(
       command,
       [url, (customProfile !== '') ? '-p ' + customProfile : '-profile ' + profilePath + ' -no-remote'].concat(flags)

--- a/index.js
+++ b/index.js
@@ -80,6 +80,7 @@ var FirefoxBrowser = function(id, baseBrowserDecorator, args, logger) {
     var command = this._getCommand();
     var profilePath = args.profile || self._tempDir;
     var flags = args.flags || [];
+    var customProfile = args.customProfile || '';
     var extensionsDir;
 
     if (Array.isArray(args.extensions)) {
@@ -95,7 +96,7 @@ var FirefoxBrowser = function(id, baseBrowserDecorator, args, logger) {
     fs.writeFileSync(profilePath + '/prefs.js', this._getPrefs(args.prefs));
     self._execCommand(
       command,
-      [url, '-profile', profilePath, '-no-remote'].concat(flags)
+        [url, (customProfile !== '') ? '-p ' + customProfile : '-profile' + profilePath , '-no-remote'].concat(flags)
     );
   };
 };

--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ var FirefoxBrowser = function(id, baseBrowserDecorator, args, logger) {
     fs.writeFileSync(profilePath + '/prefs.js', this._getPrefs(args.prefs));
     self._execCommand(
       command,
-      [url, (customProfile !== '') ? '-p ' + customProfile : '-profile ' + profilePath + ' -no-remote'].concat(flags)
+      [url, (customProfile !== '') ? ' -p ' + customProfile : '-profile ' + profilePath + ' -no-remote'].concat(flags)
     );
   };
 };

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ var FirefoxBrowser = function(id, baseBrowserDecorator, args, logger) {
     (customProfile !== '') ? flags = [] : null ;
     self._execCommand(
       command,
-      [url, (customProfile !== '') ? '-p ' + customProfile : '-profile ' + profilePath , '-no-remote'].concat(flags)
+      [url, (customProfile !== '') ? '-p ' + customProfile : '-profile ' + profilePath + '-no-remote'].concat(flags)
     );
   };
 };

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ var FirefoxBrowser = function(id, baseBrowserDecorator, args, logger) {
     (customProfile !== '') ? flags = [] : null ;
     self._execCommand(
       command,
-      [url, (customProfile !== '') ? '-p ' + customProfile : '-profile ' + profilePath + '-no-remote'].concat(flags)
+      [url, (customProfile !== '') ? '-p ' + customProfile : '-profile ' + profilePath + ' -no-remote'].concat(flags)
     );
   };
 };


### PR DESCRIPTION
Added the option to mimic "firefox.exe -p <profilename>".
When adding "customProfile" to the "customLauncher" firefox will launch said profile. The profiles list is shown when you execute "firefox.exe -p". This was added as a solution to <a herf=dn.walkme.com/General/EnvironmentTests/TestPage.html>karma-runner/karma-firefox-launcher issue #46</a> . 
Example: 

browsers: ['FirefoxWithMyExtension'],

customLaunchers: {
  FirefoxWithMyExtension: {
     base: 'Firefox',
    customProfile: 'Karma',
    extensions: [
    path.resolve(__dirname, '../my@extention.com.xpi'),
  ]
}}

This will upload the "karma" firefox i've setup beforehand using "firefox.exe -p", in it, my configs, such as imported  certs.

Ignoring this field will save the exact API of the original.
