### PR TITLE
Only use HOME environmental variable if exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,10 +75,13 @@ var getFirefoxWithFallbackOnOSX = function() {
   var homeBin;
   for (var i = 0; i < firefoxDirNames.length; i++) {
     bin = prefix + firefoxDirNames[i] + suffix;
-    homeBin = path.join(process.env.HOME, bin);
 
-    if (fs.existsSync(homeBin)) {
-      return homeBin;
+    if ('HOME' in process.env) {
+      homeBin = path.join(process.env.HOME, bin);
+
+      if (fs.existsSync(homeBin)) {
+        return homeBin;
+      }
     }
 
     if (fs.existsSync(bin)) {


### PR DESCRIPTION
This change prevents the OS X karma runtime from dying prematurely due to the plugin not starting correctly because the `HOME` environment being unset for whatever reason. Similar plugins such as the [karma-chrome-launcher](https://github.com/karma-runner/karma-chrome-launcher/blob/master/index.js#L135) have similar safeguards in place already.

Also, this function may potentially return `undefined` if the for loop is exhausted without producing a valid result, not sure if this is intended.

For more information, this issue can be reproduced very clearly with a repository I [created explicitly to reproduce this issue](https://github.com/metatoaster/karma-firefox-launcher-bug-demo/tree/failure), and the respective [failure](https://travis-ci.org/metatoaster/karma-firefox-launcher-bug-demo/jobs/171566403#L582) run (please note the exit status code: 0 on the run without the PATH variable defined and the correct status code of 1 due to the test failure that should have happened on a successful run), and then the [run with this check](https://travis-ci.org/metatoaster/karma-firefox-launcher-bug-demo/jobs/171567756#L586), where the run correctly fails.

The other issue of note is that having the plugin being available but unused shouldn't cause the whole thing to not run at all.
