### PR TITLE
Fix for issue 67

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,10 +33,12 @@ var getAllPrefixes = function () {
   var prefixes = [process.env.PROGRAMFILES, process.env['PROGRAMFILES(X86)']]
   var prefix
   for (var i = 0; i < prefixes.length; i++) {
-    for (var d = 0; d < drives.length; d += 1) {
-      prefix = drives[d] + prefixes[i].substr(1)
-      if (result.indexOf(prefix) === -1) {
-        result.push(prefix)
+    if (typeof prefixes[i] !== 'undefined') {
+      for (var d = 0; d < drives.length; d += 1) {
+        prefix = drives[d] + prefixes[i].substr(1)
+        if (result.indexOf(prefix) === -1) {
+          result.push(prefix)
+        }
       }
     }
   }


### PR DESCRIPTION
[Issue #67] On Windows 10, Karma will not load the launcher plugin, throwing the error `Cannot read property 'substr' of undefined`. People reported this behaviour happening on Windows 7 as well.
This was caused by an undefined prefix at `getAllPrefixes()`, specifically `process.env['PROGRAMFILES(X86)']`). I've simply added a check for undefined prefix strings.
Sorry, but I could test this ONLY on Windows 10.
