### PR TITLE
Remove depracted Node versions from Travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - 4
   - 6
   - stable


### PR DESCRIPTION
As referenced in [PR 77](https://github.com/karma-runner/karma-firefox-launcher/pull/77) `npm5` no longer supports these old versions. Dropping them should resolving the build errors for that PR.