### PR TITLE
Add wait for browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ var FirefoxBrowser = function (id, baseBrowserDecorator, args) {
     fs.writeFileSync(profilePath + '/prefs.js', this._getPrefs(args.prefs))
     self._execCommand(
       command,
-      [url, '-profile', profilePath, '-no-remote'].concat(flags)
+      [url, '-profile', profilePath, '-no-remote', '-wait-for-browser'].concat(flags)
     )
   }
 }


### PR DESCRIPTION
As of about Firefox 64, on Windows Firefox uses a separate launcher process which then spawns the browser process. The launcher process will terminate quickly causing karma to think something failed.

As with Mozilla's own automation tests we should use `-wait-for-browser` to make the launcher process wait for the browser process to complete and return its exit code.

Unfortunately, killing the launcher process won't kill the browser process so this isn't a complete solution. However, killing the browser process is likely more complicated while simply getting the browser to launch at all is probably enough for local testing.

This builds on top of #94 so I expect you'll want to merge that first.