### PR TITLE
chore: Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,19 @@
 sudo: false
 language: node_js
 node_js:
-  - 4
   - 6
+  - 8
   - stable
 
 before_install:
   - npm install -g npm
 
-before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+services:
+  - xvfb
 
 script:
   - npm run lint
   - npm test
-
 
 addons:
   firefox: 'latest'

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,7 +13,6 @@ module.exports = function (config) {
     logLevel: config.LOG_INFO,
     autoWatch: false,
     browsers: ['Firefox', 'FirefoxHeadless'],
-    singleRun: false,
     concurrency: Infinity,
     plugins: [
       require.resolve('./'),


### PR DESCRIPTION
Starting xvfb on travis has changed:

  https://benlimmer.com/2019/01/14/travis-ci-xvfb/

Also trying to use nodejs 4 just fails because the yarn script doesn't
appear to support it. We probably don't need to test on node 4 anymore
anyway.

Also, I'm not sure why the karma config was specifying singleRun: false.
It seems like we probably do want a single run here.