### PR TITLE
chore: Drop support for Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - 6
   - 8
   - stable
 


### PR DESCRIPTION
End-of-life was 2019-04-30 and supporting it stops us from using
dependencies that require Node 8 (e.g. is-wsl).