### PR TITLE
Update is-wsl to v2.2.0 to detect docker under WSL

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,10 +79,12 @@ var getAllPrefixesWsl = function () {
   // it starts with a drive and then record that.
   var re = /^([A-Z]):\\/i
   for (var pathElem of process.env.PATH.split(':')) {
-    var windowsPath = execSync('wslpath -w "' + pathElem + '"').toString()
-    var matches = windowsPath.match(re)
-    if (matches !== null && drives.indexOf(matches[1]) === -1) {
-      drives.push(matches[1])
+    if (fs.existsSync(pathElem)) {
+      var windowsPath = execSync('wslpath -w "' + pathElem + '"').toString()
+      var matches = windowsPath.match(re)
+      if (matches !== null && drives.indexOf(matches[1]) === -1) {
+        drives.push(matches[1])
+      }
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "Žilvinas Urbonas <zilvinas.urbon@gmail.com>"
   ],
   "dependencies": {
-    "is-wsl": "^2.1.1",
+    "is-wsl": "^2.2.0",
     "which": "^2.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1571,6 +1571,11 @@ is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
 
+is-docker@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.0.0.tgz#2cb0df0e75e2d064fe1864c37cdeacb7b2dcf25b"
+  integrity sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -1650,10 +1655,12 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
-is-wsl@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.1.1.tgz#4a1c152d429df3d441669498e2486d3596ebaf1d"
-  integrity sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==
+is-wsl@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
 
 isarray@2.0.1:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1655,7 +1655,7 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
-is-wsl@2.2.0:
+is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==


### PR DESCRIPTION
is-wsl in previous versions returns true when running in docker under wsl.  This then causes an error because the wslpath command is not found.