### PR TITLE
feat: Make Node 10 minimum required version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - 8
+  - 10
   - stable
 
 before_install:


### PR DESCRIPTION
BREAKING CHANGE: Changed minimum required version of node.js from 8 to 10.

Node 8 EOL was 2019-12-31.

Fixes #118.