### PR TITLE
fix: update name of Developer Edition on macOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -279,7 +279,7 @@ FirefoxDeveloperBrowser.prototype = {
   name: 'FirefoxDeveloper',
   DEFAULT_CMD: {
     linux: isWsl ? getFirefoxExeWsl('Firefox Developer Edition') : 'firefox',
-    darwin: getFirefoxWithFallbackOnOSX('FirefoxDeveloperEdition', 'FirefoxAurora'),
+    darwin: getFirefoxWithFallbackOnOSX('Firefox Developer Edition', 'FirefoxDeveloperEdition', 'FirefoxAurora'),
     win32: getFirefoxExe('Firefox Developer Edition')
   },
   ENV_CMD: 'FIREFOX_DEVELOPER_BIN'


### PR DESCRIPTION
Hi everyone, this PR updates the name that the plugin uses to locate the Developer Edition on macOS. For quite some time now the name is "Firefox Developer Edition" with spaces. The old name is still available as a fallback which means this should not be a breaking change.

Please let me know if I should change anything to make this PR acceptable.