### PR TITLE
fix: launcher does not kill firefox.exe on WSL

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ if (isWsl && which.sync('firefox', { nothrow: true })) {
  * `'"firefox.exe","14972","Console","1","5.084 K"\r\n"firefox.exe","12204","Console","1","221.656 K"'`
  * @returns {string[]} Array of String PIDs. Can be empty.
  */
- var extractPids = tasklist => tasklist
+ const extractPids = tasklist => tasklist
     .split (',')
     .filter (x => /^"\d{3,10}"$/.test (x))
     .map (pid => pid.replace (/"/g, ''))
@@ -42,8 +42,8 @@ if (isWsl && which.sync('firefox', { nothrow: true })) {
   * @param {function} log An instance of logger.create
   * @returns {{(command:string):string}}
   */
-var createSafeExecSync = log => command => {
-  var output = ''
+const createSafeExecSync = log => command => {
+  let output = ''
   try {
     output = String (execSync(command))
   } catch (err) {
@@ -291,8 +291,7 @@ var FirefoxBrowser = function (id, baseBrowserDecorator, args, logger) {
         // terminated.
       }
     } else if (isWsl) {
-      //
-      var tasklist = extractPids (safeExecSync ('tasklist.exe /FI "IMAGENAME eq firefox.exe" /FO CSV /NH /SVC'))
+      const tasklist = extractPids (safeExecSync ('tasklist.exe /FI "IMAGENAME eq firefox.exe" /FO CSV /NH /SVC'))
         .filter(pid => browserProcessPidWsl.indexOf(pid) === -1)
 
       log.warn ('Killing the following PIDs: %s', tasklist)

--- a/index.js
+++ b/index.js
@@ -249,12 +249,11 @@ var FirefoxBrowser = function (id, baseBrowserDecorator, args, logger) {
       isWsl ? execSync('wslpath -w ' + profilePath).toString().trim() : profilePath
 
     if (isWsl) {
-      // possible level of logging: log.error || log.warn || log.info || log.debug
       log.warn ('WSL environment detected: Please do not open Firefox while running tests as it will be killed after the test!')
       log.warn ('WSL environment detected: See https://github.com/karma-runner/karma-firefox-launcher/issues/101#issuecomment-891850143')
 
       browserProcessPidWsl = extractPids (safeExecSync ('tasklist.exe /FI "IMAGENAME eq firefox.exe" /FO CSV /NH /SVC'))
-      log.debug ('Recorded PIDs not to kill: %s', browserProcessPidWsl)
+      log.debug ('Recorded PIDs not to kill:', browserProcessPidWsl)
     }
 
     // If we are using the launcher process, make it print the child process ID
@@ -296,7 +295,7 @@ var FirefoxBrowser = function (id, baseBrowserDecorator, args, logger) {
       const tasklist = extractPids (safeExecSync ('tasklist.exe /FI "IMAGENAME eq firefox.exe" /FO CSV /NH /SVC'))
         .filter(pid => browserProcessPidWsl.indexOf(pid) === -1)
 
-      log.warn ('Killing the following PIDs: %s', tasklist)
+      log.debug ('Killing the following PIDs:', tasklist)
       log.debug (safeExecSync ('taskkill.exe /F ' + tasklist.map (pid => `/PID ${pid}`).join (' ')))
     }
 

--- a/index.js
+++ b/index.js
@@ -296,7 +296,9 @@ var FirefoxBrowser = function (id, baseBrowserDecorator, args, logger) {
         .filter(pid => browserProcessPidWsl.indexOf(pid) === -1)
 
       log.debug ('Killing the following PIDs:', tasklist)
-      log.debug (safeExecSync ('taskkill.exe /F ' + tasklist.map (pid => `/PID ${pid}`).join (' ')))
+
+      const killResult = safeExecSync ('taskkill.exe /F ' + tasklist.map (pid => `/PID ${pid}`).join (' '))
+      log.debug (killResult)
     }
 
     return process.nextTick(done)

--- a/index.js
+++ b/index.js
@@ -40,14 +40,16 @@ if (isWsl && which.sync('firefox', { nothrow: true })) {
   * Curried function version of safeExecSync with reference to logger
   * in a closure.
   * @param {function} log An instance of logger.create
-  * @returns {{(command:string):string}}
+  * @returns {{(command:string):string}} A closure with reference to logger
   */
 const createSafeExecSync = log => command => {
   let output = ''
   try {
     output = String (execSync(command))
   } catch (err) {
-    log.warn (String (err))
+    // Something went wrong
+    // but we can always continue
+    log.debug (String (err))
   }
   return output
 }

--- a/index.js
+++ b/index.js
@@ -211,7 +211,7 @@ var makeHeadlessVersion = function (Browser) {
 var FirefoxBrowser = function (id, baseBrowserDecorator, args, logger) {
   baseBrowserDecorator(this)
 
-  const log = logger.create('FirefoxLauncher')
+  const log = logger.create(this.name + 'Launcher')
   const safeExecSync = createSafeExecSync (log)
   let browserProcessPid
   let browserProcessPidWsl = []

--- a/index.js
+++ b/index.js
@@ -289,7 +289,6 @@ var FirefoxBrowser = function (baseBrowserDecorator, args, logger, emitter) {
   if (isWsl) {
     // exit: will run for each browser when all tests has finished
     emitter.on ('exit', (done) => {
-      log.error ('browserProcessPidWsl', browserProcessPidWsl)
       const tasklist = extractPids (safeExecSync ('tasklist.exe /FI "IMAGENAME eq firefox.exe" /FO CSV /NH /SVC'))
         .filter(pid => browserProcessPidWsl.indexOf(pid) === -1)
 


### PR DESCRIPTION
**Record PIDs for firefox.exe on WSL and kill all processes not recorded on start-up.**

After testing both regular Firefox and Firefox Developer Edition, I came to the conclusion that the executable is always `firefox.exe` - I really hope that is correct.

At first I wrote this patch in ES5 but since we already use destructuring assignment at the top (`var { execSync } = require('child_process')`), I re-wrote it to ES6/ES2015.

According to SO the highest PID on Windows is [0xFFFFFFFC](https://stackoverflow.com/questions/17868218/what-is-the-maximum-process-id-on-windows) which I believe is 10 digits. The lowest PID is 0 but only PIDs above 100 seems to be user-land processes. The first ones seems to be reserved for Windows OS. The way I extract PIDs is by looking for _whole_ integers, so I could look for 2 digits PIDs but never 1, since we would then get Session Number as PID. If a PID in the 0-9 range can be a Firefox process, then `extractPids` logic needs to change. But I very much doubt that. Currently I test for integers with 3-10 digits.

This PR passes all tests on my machine on WSL, although it will kill the second test mid-air but then Karma retries and everything works out. [Karma-browserstack-launcher uses a different exit/kill event](https://github.com/karma-runner/karma-browserstack-launcher/blob/master/index.js#L29) but that looks specific to their launcher and might not help at all.

Ref: https://github.com/karma-runner/karma-firefox-launcher/issues/101#issuecomment-891850143