### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ const getAllPrefixes = function () {
   for (let i = 0; i < prefixes.length; i++) {
     if (typeof prefixes[i] !== 'undefined') {
       for (let d = 0; d < drives.length; d += 1) {
-        prefix = drives[d] + prefixes[i].substr(1)
+        prefix = drives[d] + prefixes[i].slice(1)
         if (result.indexOf(prefix) === -1) {
           result.push(prefix)
         }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.