### PR TITLE
Switch macOS from `firefox-bin` to `firefox`

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,7 +171,7 @@ const getFirefoxWithFallbackOnOSX = function () {
 
   const firefoxDirNames = Array.prototype.slice.call(arguments)
   const prefix = '/Applications/'
-  const suffix = '.app/Contents/MacOS/firefox-bin'
+  const suffix = '.app/Contents/MacOS/firefox'
 
   let bin
   let homeBin


### PR DESCRIPTION
Upstream:
* "firefox-bin is broken". https://bugzilla.mozilla.org/show_bug.cgi?id=1871447
* "remove firefox-bin". https://bugzilla.mozilla.org/show_bug.cgi?id=1873782

Long story short:
* Firefox has shipped both for a long time.
* Firefox signs the binaries in a way that  only `firefox` passes Apple's "hightened" security rules.
* Firefox 121 adds support for Apple's Passkey feature and that raised the level of security rules it has to pass, thus making `firefox-bin` appear like an imposter. This means macOS terminates `firefox-bin` with the message `Killed: 9`. 

Fixes https://github.com/karma-runner/karma-firefox-launcher/issues/328.