### PR TITLE
feat: disable Firefox telemetry data submission by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ const PREFS = [
   'user_pref("extensions.autoDisableScopes", 0);',
   'user_pref("browser.tabs.remote.autostart", false);',
   'user_pref("browser.tabs.remote.autostart.2", false);',
-  'user_pref("extensions.enabledScopes", 15);'
+  'user_pref("extensions.enabledScopes", 15);',
+  'user_pref("datareporting.policy.dataSubmissionEnabled", false);'
 ].join('\n')
 
 // NOTE: add 'config.browsers' to get which browsers are started


### PR DESCRIPTION
Firefox performs a telemetry data-submission phone-home at browser startup. In a headless test browser this serves no purpose and adds measurable overhead to every launch.

Add datareporting.policy.dataSubmissionEnabled=false to the default PREFS so launches skip it. Measured locally this consistently gives roughly 4% faster test runs across paired runs, with no change in test results.

https://phabricator.wikimedia.org/T427103#11987341